### PR TITLE
Fix missing frequencies during DVB-C scan (Europe)

### DIFF
--- a/countries.c
+++ b/countries.c
@@ -333,8 +333,7 @@ switch (channellist) {
         case DVBC_QAM: //EUROPE
                 switch (channel) {
                       //case  0 ... 1:  
-                        case  5 ... 12: return   73000000;
-                        case 22 ... 90: return  138000000;
+                        case  0 ... 93: return  114000000;
                         default:        return  SKIP_CHANNEL;
                         }
         case DVBC_FI:  //FINLAND, QAM128


### PR DESCRIPTION
The DVB-C scan skips some frequencies that are only used for DVB-C (and not terrestrial). So some channels are never found.
The purposed fix will scan every allowed channel in the 8 MHz grid from 114 MHz to 858 MHz. Since the channel numbers in Wirbelscan have no further meaning I did not map them to be compatible to old analog channel numbers and just used the start frequency.